### PR TITLE
various codecs support (e.g H.264, HEVC, VP8, VP9, MJPEG, ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,5 @@ install(FILES hve.h DESTINATION include)
 add_executable(hve-encode-raw-h264 examples/hve_encode_raw_h264.c)
 target_link_libraries(hve-encode-raw-h264 hve)
 
+add_executable(hve-encode-raw-hevc10 examples/hve_encode_raw_hevc10.c)
+target_link_libraries(hve-encode-raw-hevc10 hve)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library wraps hardware video encoding in a simple interface.
 There are no performance loses (at the cost of library flexibility).
 
-Currently it supports VAAPI and H.264 standard.
+Currently it supports VAAPI and various codecs (H.264, HEVC, ...).
 
 See library [documentation](https://bmegli.github.io/hardware-video-encoder/group__interface.html).
 
@@ -13,10 +13,10 @@ See [hardware-video-streaming](https://github.com/bmegli/hardware-video-streamin
 
 ## Intended Use
 
-Raw H.264 encoding:
+Raw encoding (H264, HEVC, ...):
 - custom network streaming protocols
 - low latency streaming
-- raw H.264 dumping
+- raw dumping (H264, HEVC, ...)
 - ...
 
 Complex pipelines (muxing, scaling, color conversions, filtering) are beyond the scope of this library.
@@ -63,11 +63,16 @@ cmake ..
 make
 ```
 
-## Running Example
+## Running Examples
 
 ``` bash
 # ./hve-encode-raw-h264 <number-of-seconds> [device]
 ./hve-encode-raw-h264 10
+```
+
+``` bash
+# ./hve-encode-raw-hevc10 <number-of-seconds> [device]
+./hve-encode-raw-hevc10 10
 ```
 
 ### Troubleshooting
@@ -81,19 +86,21 @@ sudo apt-get install vainfo
 vainfo --display drm --device /dev/dri/renderD128
 ```
 
-Once you identify your Intel device run the example, e.g.
+Once you identify your Intel device run the examples, e.g.
 
 ```bash
 ./hve-encode-raw-h264 10 /dev/dri/renderD128
+./hve-encode-raw-hevc10 10 /dev/dri/renderD128
 ```
 
 ## Testing
 
-Play result raw H.264 file with FFmpeg:
+Play result raw H.264/HEVC file with FFmpeg:
 
 ``` bash
-# output goes to output.h264 file 
+# output goes to output.h264/output.hevc file
 ffplay output.h264
+ffplay output.hevc
 ```
 
 You should see procedurally generated video (moving through greyscale).
@@ -110,11 +117,11 @@ There are just 4 functions and 3 user-visible data types:
 
 ```C
 	struct hve_config hardware_config = {WIDTH, HEIGHT, FRAMERATE, DEVICE,
-					PIXEL_FORMAT, PROFILE, BFRAMES, BITRATE};
+				ENCODER, PIXEL_FORMAT, PROFILE, BFRAMES, BITRATE};
 	struct hve *hardware_encoder=hve_init(&hardware_config);
 	struct hve_frame frame = { 0 };
 
-	//later assuming PIXEL_FORMAT is "nv12" (you can use something else)
+	//later assuming PIXEL_FORMAT is "nv12" (you may use something else)
 
 	//fill with your stride (width including padding if any)
 	frame.linesize[0] = frame.linesize[1] = WIDTH;

--- a/examples/hve_encode_raw_h264.c
+++ b/examples/hve_encode_raw_h264.c
@@ -1,5 +1,5 @@
 /*
- * HVE Hardware Video Encoder library example of encoding through VAAPI to H.264
+ * HVE Hardware Video Encoder library example of encoding through VAAPI to HEVC 10 bits per channel
  *
  * Copyright 2019 (C) Bartosz Meglicki <meglickib@gmail.com>
  *
@@ -19,7 +19,8 @@ const int HEIGHT=720;
 const int FRAMERATE=30;
 int SECONDS=10;
 const char *DEVICE=NULL; //NULL for default or device e.g. "/dev/dri/renderD128"
-const char *PIXEL_FORMAT="p010le"; //NULL for default (NV12) or pixel format e.g. "rgb0"
+const char *ENCODER="hevc_vaapi";//NULL for default (h264_vaapi) or FFmpeg encoder e.g. "hevc_vaapi", ...
+const char *PIXEL_FORMAT="p010le"; //NULL for default (nv12) or pixel format e.g. "rgb0", ...
 const int PROFILE=FF_PROFILE_HEVC_MAIN_10; //or FF_PROFILE_H264_MAIN, FF_PROFILE_H264_CONSTRAINED_BASELINE, ...
 const int BFRAMES=0; //max_b_frames, set to 0 to minimize latency, non-zero to minimize size
 const int BITRATE=0; //average bitrate in VBR
@@ -36,7 +37,7 @@ int main(int argc, char* argv[])
 		return -1;
 
 	//prepare library data
-	struct hve_config hardware_config = {WIDTH, HEIGHT, FRAMERATE, DEVICE, PIXEL_FORMAT, PROFILE, BFRAMES, BITRATE};
+	struct hve_config hardware_config = {WIDTH, HEIGHT, FRAMERATE, DEVICE, ENCODER, PIXEL_FORMAT, PROFILE, BFRAMES, BITRATE};
 	struct hve *hardware_encoder;
 
 	//prepare file for raw HEVC output
@@ -98,8 +99,8 @@ int encoding_loop(struct hve *hardware_encoder, FILE *output_file)
 
 		while( (packet=hve_receive_packet(hardware_encoder, &failed)) )
 		{
-			//packet.data is H.264 encoded frame of packet.size length
-			//here we are dumping it to raw H.264 file as example
+			//packet.data is HEVC encoded frame of packet.size length
+			//here we are dumping it to raw HEVC file as example
 			//yes, we ignore the return value of fwrite for simplicty
 			//it could also fail in harsh real world...
 			fwrite(packet->data, packet->size, 1, output_file);
@@ -143,10 +144,11 @@ int hint_user_on_failure(char *argv[])
 	fprintf(stderr, "%s 10 /dev/dri/renderD128\n", argv[0]);
 	return -1;
 }
+
 void hint_user_on_success()
 {
 	printf("finished successfully\n");
-	printf("output written to \"outout.hevc\" file\n");
+	printf("output written to \"out.hevc\" file\n");
 	printf("test with:\n\n");
 	printf("ffplay output.hevc\n");
 }

--- a/examples/hve_encode_raw_hevc10.c
+++ b/examples/hve_encode_raw_hevc10.c
@@ -1,5 +1,5 @@
 /*
- * HVE Hardware Video Encoder library example of encoding through VAAPI to H.264
+ * HVE Hardware Video Encoder library example of encoding through VAAPI to HEVC 10 bits per channel
  *
  * Copyright 2019 (C) Bartosz Meglicki <meglickib@gmail.com>
  *
@@ -10,7 +10,7 @@
  */
 
 #include <stdio.h> //printf, fprintf
-#include <inttypes.h> //uint8_t
+#include <inttypes.h> //uint8_t, uint16_t
 
 #include "../hve.h"
 
@@ -19,9 +19,9 @@ const int HEIGHT=720;
 const int FRAMERATE=30;
 int SECONDS=10;
 const char *DEVICE=NULL; //NULL for default or device e.g. "/dev/dri/renderD128"
-const char *ENCODER=NULL;//NULL for default (h264_vaapi) or FFmpeg encoder e.g. "hevc_vaapi", ...
-const char *PIXEL_FORMAT="nv12"; //NULL for default (NV12) or pixel format e.g. "rgb0"
-const int PROFILE=FF_PROFILE_H264_HIGH; //or FF_PROFILE_HEVC_MAIN, FF_PROFILE_H264_CONSTRAINED_BASELINE, ...
+const char *ENCODER="hevc_vaapi";//NULL for default (h264_vaapi) or FFmpeg encoder e.g. "hevc_vaapi", ...
+const char *PIXEL_FORMAT="p010le"; //NULL for default (nv12) or pixel format e.g. "rgb0", ...
+const int PROFILE=FF_PROFILE_HEVC_MAIN_10; //or FF_PROFILE_HEVC_MAIN, ...
 const int BFRAMES=0; //max_b_frames, set to 0 to minimize latency, non-zero to minimize size
 const int BITRATE=0; //average bitrate in VBR
 
@@ -40,8 +40,8 @@ int main(int argc, char* argv[])
 	struct hve_config hardware_config = {WIDTH, HEIGHT, FRAMERATE, DEVICE, ENCODER, PIXEL_FORMAT, PROFILE, BFRAMES, BITRATE};
 	struct hve *hardware_encoder;
 
-	//prepare file for raw H.264 output
-	FILE *output_file = fopen("output.h264", "w+b");
+	//prepare file for raw HEVC output
+	FILE *output_file = fopen("output.hevc", "w+b");
 	if(output_file == NULL)
 		return fprintf(stderr, "unable to open file for output\n");
 
@@ -67,16 +67,16 @@ int main(int argc, char* argv[])
 int encoding_loop(struct hve *hardware_encoder, FILE *output_file)
 {
 	struct hve_frame frame = { 0 };
-	int frames=SECONDS*FRAMERATE, f, failed;
+	int frames=SECONDS*FRAMERATE, f, failed, i;
 
-	//we are working with NV12 because we specified nv12 pixel format
+	//we are working with P010LE because we specified p010le pixel format
 	//when calling hve_init, in principle we could use other format
 	//if hardware supported it (e.g. RGB0 is supported on my Intel)
-	uint8_t Y[WIDTH*HEIGHT]; //dummy NV12 luminance data
-	uint8_t color[WIDTH*HEIGHT/2]; //dummy NV12 color data
+	uint16_t Y[WIDTH*HEIGHT]; //dummy p010le luminance data (or p016le)
+	uint16_t color[WIDTH*HEIGHT/2]; //dummy p010le color data (or p016le)
 
 	//fill with your stride (width including padding if any)
-	frame.linesize[0] = frame.linesize[1] = WIDTH;
+	frame.linesize[0] = frame.linesize[1] = WIDTH*2;
 
 	//encoded data is returned in FFmpeg packet
 	AVPacket *packet;
@@ -84,12 +84,14 @@ int encoding_loop(struct hve *hardware_encoder, FILE *output_file)
 	for(f=0;f<frames;++f)
 	{
 		//prepare dummy image data, normally you would take it from camera or other source
-		memset(Y, f % 255, WIDTH*HEIGHT); //NV12 luminance (ride through greyscale)
-		memset(color, 128, WIDTH*HEIGHT/2); //NV12 UV (no color really)
-
-		//fill hve_frame with pointers to your data in NV12 pixel format
-		frame.data[0]=Y;
-		frame.data[1]=color;
+		for(int i=0;i<WIDTH*HEIGHT;++i)
+			Y[i] = UINT16_MAX * f / frames; //linear interpolation between 0 and UINT16_MAX
+		for(int i=0;i<WIDTH*HEIGHT/2;++i)
+			color[i] = UINT16_MAX / 2; //dummy middle value for U/V, equals 128 << 8, equals 32768
+		//fill hve_frame with pointers to your data in P010LE pixel format
+		//note that we have actually prepared P016LE data but it is binary compatible with P010LE
+		frame.data[0]=(uint8_t*)Y;
+		frame.data[1]=(uint8_t*)color;
 
 		//encode this frame
 		if( hve_send_frame(hardware_encoder, &frame) != HVE_OK)
@@ -97,8 +99,8 @@ int encoding_loop(struct hve *hardware_encoder, FILE *output_file)
 
 		while( (packet=hve_receive_packet(hardware_encoder, &failed)) )
 		{
-			//packet.data is H.264 encoded frame of packet.size length
-			//here we are dumping it to raw H.264 file as example
+			//packet.data is HEVC encoded frame of packet.size length
+			//here we are dumping it to raw HEVC file as example
 			//yes, we ignore the return value of fwrite for simplicty
 			//it could also fail in harsh real world...
 			fwrite(packet->data, packet->size, 1, output_file);
@@ -142,10 +144,11 @@ int hint_user_on_failure(char *argv[])
 	fprintf(stderr, "%s 10 /dev/dri/renderD128\n", argv[0]);
 	return -1;
 }
+
 void hint_user_on_success()
 {
 	printf("finished successfully\n");
-	printf("output written to \"outout.h264\" file\n");
+	printf("output written to \"out.hevc\" file\n");
 	printf("test with:\n\n");
-	printf("ffplay output.h264\n");
+	printf("ffplay output.hevc\n");
 }

--- a/hve.c
+++ b/hve.c
@@ -58,16 +58,10 @@ struct hve *hve_init(const struct hve_config *config)
 		fprintf(stderr, "hve: failed to create a VAAPI device\n");
 		return hve_close_and_return_null(h);
 	}
-	//ffmpeg -encoders | grep vaapi
-	/*
-	 * V..... h264_vaapi           H.264/AVC (VAAPI) (codec h264)
-	 * V..... hevc_vaapi           H.265/HEVC (VAAPI) (codec hevc)
-	 * V..... mjpeg_vaapi          MJPEG (VAAPI) (codec mjpeg)
-	 * V..... mpeg2_vaapi          MPEG-2 (VAAPI) (codec mpeg2video)
-	 * V..... vp8_vaapi            VP8 (VAAPI) (codec vp8)
-	 * V..... vp9_vaapi            VP9 (VAAPI) (codec vp9)
-	 */
-	if(!(codec = avcodec_find_encoder_by_name("hevc_vaapi")))
+
+	const char *encoder = (config->encoder != NULL && config->encoder[0] != '\0') ? config->encoder : "h264_vaapi";
+
+	if(!(codec = avcodec_find_encoder_by_name(encoder)))
 	{
 		fprintf(stderr, "hve: could not find encoder\n");
 		return hve_close_and_return_null(h);
@@ -86,8 +80,6 @@ struct hve *hve_init(const struct hve_config *config)
 	h->avctx->sample_aspect_ratio = (AVRational){ 1, 1 };
 	h->avctx->pix_fmt = AV_PIX_FMT_VAAPI;
 
-	//Profiles
-	//https://ffmpeg.org/doxygen/3.4/avcodec_8h.html
 	if(config->profile)
 		h->avctx->profile = config->profile;
 	h->avctx->max_b_frames = config->max_b_frames;

--- a/hve.c
+++ b/hve.c
@@ -58,8 +58,16 @@ struct hve *hve_init(const struct hve_config *config)
 		fprintf(stderr, "hve: failed to create a VAAPI device\n");
 		return hve_close_and_return_null(h);
 	}
-
-	if(!(codec = avcodec_find_encoder_by_name("h264_vaapi")))
+	//ffmpeg -encoders | grep vaapi
+	/*
+	 * V..... h264_vaapi           H.264/AVC (VAAPI) (codec h264)
+	 * V..... hevc_vaapi           H.265/HEVC (VAAPI) (codec hevc)
+	 * V..... mjpeg_vaapi          MJPEG (VAAPI) (codec mjpeg)
+	 * V..... mpeg2_vaapi          MPEG-2 (VAAPI) (codec mpeg2video)
+	 * V..... vp8_vaapi            VP8 (VAAPI) (codec vp8)
+	 * V..... vp9_vaapi            VP9 (VAAPI) (codec vp9)
+	 */
+	if(!(codec = avcodec_find_encoder_by_name("hevc_vaapi")))
 	{
 		fprintf(stderr, "hve: could not find encoder\n");
 		return hve_close_and_return_null(h);
@@ -78,6 +86,8 @@ struct hve *hve_init(const struct hve_config *config)
 	h->avctx->sample_aspect_ratio = (AVRational){ 1, 1 };
 	h->avctx->pix_fmt = AV_PIX_FMT_VAAPI;
 
+	//Profiles
+	//https://ffmpeg.org/doxygen/3.4/avcodec_8h.html
 	if(config->profile)
 		h->avctx->profile = config->profile;
 	h->avctx->max_b_frames = config->max_b_frames;

--- a/hve.h
+++ b/hve.h
@@ -47,12 +47,29 @@ struct hve;
  * @brief Encoder configuration
  *
  * The device can be:
- * - NULL (select automatically)
+ * - NULL or empty string (select automatically)
  * - point to valid device e.g. "/dev/dri/renderD128" for vaapi
  *
  * If you have multiple VAAPI devices (e.g. NVidia GPU + Intel) you may have
  * to specify Intel directly. NVidia will not work through VAAPI for encoding
  * (it works through VAAPI-VDPAU bridge and VDPAU is only for decoding).
+ *
+ * The encoder can be:
+ * - NULL or empty string for "h264_vaapi"
+ * - valid ffmpeg encoder
+ *
+ * You may check encoders supported by your hardware with ffmpeg:
+ * @code
+ * ffmpeg -encoders | grep vaapi
+ * @endcode
+ *
+ * Encoders typically can be:
+ * - h264_vaapi
+ * - hevc_vaapi
+ * - mjpeg_vaapi
+ * - mpeg2_vaapi
+ * - vp8_vaapi
+ * - vp9_vaapi
  *
  * The pixel_format (format of what you upload) typically can be:
  * - nv12 (this is generally safe choice)
@@ -62,16 +79,27 @@ struct hve;
  * - yuv422p
  * - rgb0
  * - bgr0
+ * - p010le
  *
  * There are no software color conversions in this library.
  *
  * For pixel format explanation see:
  * <a href="https://ffmpeg.org/doxygen/3.4/pixfmt_8h.html#a9a8e335cf3be472042bc9f0cf80cd4c5">FFmpeg pixel formats</a>
  *
- * The profile (H.264 profile) can typically be:
+ * The available profiles depend on used encoder. Use 0 to guess from input.
+ *
+ * For possible profiles see:
+ * <a href="https://ffmpeg.org/doxygen/3.4/avcodec_8h.html#ab424d258655424e4b1690e2ab6fcfc66">FFmpeg profiles</a>
+ *
+ * For H.264 profile can typically be:
  * - FF_PROFILE_H264_CONSTRAINED_BASELINE
  * - FF_PROFILE_H264_MAIN
  * - FF_PROFILE_H264_HIGH
+ * - ...
+ *
+ * For HEVC profile can typically be:
+ * - FF_PROFILE_HEVC_MAIN
+ * - FF_PROFILE_HEVC_MAIN_10 (10 bit channel precision)
  * - ...
  *
  * You may check profiles supported by your hardware with vainfo:
@@ -93,8 +121,9 @@ struct hve_config
 	int height; //!< height of the encoded frames
 	int framerate; //!< framerate of the encoded video
 	const char *device; //!< NULL / "" or device, e.g. "/dev/dri/renderD128"
-	const char *pixel_format; //!< NULL / "" for NV12 or format, e.g. "rgb0", "bgr0", "nv12", "yuv420p"
-	int profile; //!< 0 to guess from input or profile e.g. FF_PROFILE_H264_MAIN, FF_PROFILE_H264_HIGH
+	const char *encoder; //!< NULL / "" or encoder, e.g. "h264_vaapi"
+	const char *pixel_format; //!< NULL / "" for NV12 or format, e.g. "rgb0", "bgr0", "nv12", "yuv420p", "p010le"
+	int profile; //!< 0 to guess from input or profile e.g. FF_PROFILE_H264_MAIN, FF_PROFILE_H264_HIGH, FF_PROFILE_HEVC_MAIN, ...
 	int max_b_frames; //!< maximum number of B-frames between non-B-frames (disable if you need low latency)
 	int bit_rate; //!< the average bitrate in VBR mode
 };


### PR DESCRIPTION
- extends `hve_config` with `encoder` field
- by default (NULL, "") set to "h264_vaapi"
- adds HEVC 10 bit per channel encoding example
- documentation update (codecs, profiles)
- readme update (codecs, examples)
